### PR TITLE
Register SnekX token - Doraemon the Cat

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "473d1a9a071e22a1711c760dcb3405a1888df4e5105bbc394206ffc6446f7261656d6f6e746865436174": {
+    "token_id": "473d1a9a071e22a1711c760dcb3405a1888df4e5105bbc394206ffc6446f7261656d6f6e746865436174",
+    "token_policy": "473d1a9a071e22a1711c760dcb3405a1888df4e5105bbc394206ffc6",
+    "token_ascii": "Doraemon the Cat",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "DORAE"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: Qmab1e6no9XZPMjSFAPcNt9c2C86FmrMHVVyDDb5VJW8LD, SnekX payment: 28440511ede51a5238ba5f9720471aab9db553714be7c99e1b430a1d7c133d82 