### PR TITLE
Register SnekX token - PickleJones

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "dae5d63eb4940a5d2d5b5413612d3b89dd7ca61449d64a6ed126a2605069636b6c654a6f6e6573": {
+    "token_id": "dae5d63eb4940a5d2d5b5413612d3b89dd7ca61449d64a6ed126a2605069636b6c654a6f6e6573",
+    "token_policy": "dae5d63eb4940a5d2d5b5413612d3b89dd7ca61449d64a6ed126a260",
+    "token_ascii": "PickleJones",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "PICKLE"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmQf8CtxTAJNitvaexRUbfwbBMKCymSsa56thBvSB6HQ1P, SnekX payment: 23a495e8b94617e2be9e1b71d5fb3f707aac4a0b49b33f72ee4616e00fcc3640 