### PR TITLE
Register SnekX token - Base Mobile Token

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "c50611dc16221c070b75f883803f02ffe125d348d709a72cfd4010b4426173654d6f62696c65546f6b656e": {
+    "token_id": "c50611dc16221c070b75f883803f02ffe125d348d709a72cfd4010b4426173654d6f62696c65546f6b656e",
+    "token_policy": "c50611dc16221c070b75f883803f02ffe125d348d709a72cfd4010b4",
+    "token_ascii": "Base Mobile Token",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "BaseWMT"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmPSMLvfRD9Ps7xik9L6i5rFqUZb3vE2PVL11rU25TRUeU, SnekX payment: 4ed97e64648affd59cedd8df2b18293d38eec627c220df6d8705754542c2f69a 