### PR TITLE
Register SnekX token - LAPETITEANAL

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "7445fff595cccf8f01daf1de78e313ac2bcf504219eee0dbe5245c404c41504554495445414e414c": {
+    "token_id": "7445fff595cccf8f01daf1de78e313ac2bcf504219eee0dbe5245c404c41504554495445414e414c",
+    "token_policy": "7445fff595cccf8f01daf1de78e313ac2bcf504219eee0dbe5245c40",
+    "token_ascii": "LAPETITEANAL",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "PETITEANL"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmZaS1JasaiVVmH3XWxPac3ohe36NSzQMCAZj9exWftnem, SnekX payment: 47fb85ad3be1961694de7d8ed402dcc43eced38629c8449091d61bd35512c183 