### PR TITLE
Register SnekX token - BIGPEY

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "ca4803eace7610caf10c5015b420be8a597b4b1c68d230321ff40766424947504559": {
+    "token_id": "ca4803eace7610caf10c5015b420be8a597b4b1c68d230321ff40766424947504559",
+    "token_policy": "ca4803eace7610caf10c5015b420be8a597b4b1c68d230321ff40766",
+    "token_ascii": "BIGPEY",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "BIGPEY"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmUkbGAazL81mzedrFAXbc8qgBjHf9ng5A4aziwu21pEQL, SnekX payment: f7fb36065bf2655f33c36cd9030d144372a3be7a6e029427b7503e24bc9ed205 