### PR TITLE
Register SnekX token - ARFA

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "bf5a705246a2b754f2c2676f71272e7444317b6ef6c3384b64b9303341524641": {
+    "token_id": "bf5a705246a2b754f2c2676f71272e7444317b6ef6c3384b64b9303341524641",
+    "token_policy": "bf5a705246a2b754f2c2676f71272e7444317b6ef6c3384b64b93033",
+    "token_ascii": "ARFA",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "ARFA"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmQeEm3aTzJTBHa5ptMaYLyWJw6D1yLKHBm8WUtXDwU7Bq, SnekX payment: 0e31f32e40aa3b66c36f73e3ec4ac1420664dbdfa1cee33f878da538f83fb3c5 