### PR TITLE
Register SnekX token - CATERALL

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "67d14e1c98cd235f4f2dad0b729cf017cbd59bdf2c9c48e2e645196e4341544552414c4c": {
+    "token_id": "67d14e1c98cd235f4f2dad0b729cf017cbd59bdf2c9c48e2e645196e4341544552414c4c",
+    "token_policy": "67d14e1c98cd235f4f2dad0b729cf017cbd59bdf2c9c48e2e645196e",
+    "token_ascii": "CATERALL",
+    "is_verified": true,
+    "decimals": "4",
+    "ticker": "CATERALL"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmWKGMfNqFo1w3HpDM9PrXzU4W3Rd45TqsCSsuxXT44RVJ, SnekX payment: cd9b6fbf3d9bb2b1466dcb73c07812fbf61557bf4ea18a4db7edfdea8e90fe04 