### PR TITLE
Register SnekX token - ShiteCoin

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "18ed5b7206f4f409b81f515f354121b47421ad95dfa8de5e188bddba5368697465436f696e": {
+    "token_id": "18ed5b7206f4f409b81f515f354121b47421ad95dfa8de5e188bddba5368697465436f696e",
+    "token_policy": "18ed5b7206f4f409b81f515f354121b47421ad95dfa8de5e188bddba",
+    "token_ascii": "ShiteCoin",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "ShiteCoin"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmYtNGUX27xKzongQtPKELTmSfM8BEiFZ6kxVWQ36qzDgH, SnekX payment: 6ebaac7ed08e1ac248e9bab696318d3e26aa2fcd2afbff062b943cb9406f4fe5 