### PR TITLE
Register SnekX token - Nerdkinson

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "8716083bfb0976ea8c1aecb8db3c1772a1d4e8fae78d6fb1f3cc412a4e6572646b696e736f6e": {
+    "token_id": "8716083bfb0976ea8c1aecb8db3c1772a1d4e8fae78d6fb1f3cc412a4e6572646b696e736f6e",
+    "token_policy": "8716083bfb0976ea8c1aecb8db3c1772a1d4e8fae78d6fb1f3cc412a",
+    "token_ascii": "Nerdkinson",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "NERD"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmXuFPs6EDFuSFgwSk1Cy58hhpHjz9xdq5cCGkSJo4nzw5, SnekX payment: 2797ebce9f27a6162605208142992ddf1dc598c2d135242b2dd384c285551ba8 