### PR TITLE
Register SnekX token - Nips

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "998917deb33d880edf2594a19f81800b54db030e93774e4fc497381e4e697073": {
+    "token_id": "998917deb33d880edf2594a19f81800b54db030e93774e4fc497381e4e697073",
+    "token_policy": "998917deb33d880edf2594a19f81800b54db030e93774e4fc497381e",
+    "token_ascii": "Nips",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Nips"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmbgzywroP1dVmUMT3a1K7kT7iEYKhcybgsfcCeneK4G4b, SnekX payment: b8480bce072c491a316d057c3bd4bf83b5b9278e1928ef65883847d4fd319bb3 