### PR TITLE
Register SnekX token - WALDO

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "8c5f87af0662799d38dc070b06d4415f7c2314ee9fbfcd3df560c16d57414c444f": {
+    "token_id": "8c5f87af0662799d38dc070b06d4415f7c2314ee9fbfcd3df560c16d57414c444f",
+    "token_policy": "8c5f87af0662799d38dc070b06d4415f7c2314ee9fbfcd3df560c16d",
+    "token_ascii": "WALDO",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "WALDO"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmRxoWpexvdDkKrmQZtnPSfLqgJuBeorUfYAUTditLhmJQ, SnekX payment: a8f7b0c9ea2bfcdbcaecfc012fdefc8cc260827406a2a5bec36987e24894b6ba 