### PR TITLE
Register SnekX token - SPIDEY

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "ab5a47a5e65559a94d4db2bbdd5ca766278f95fc039469031155d5fd535049444559": {
+    "token_id": "ab5a47a5e65559a94d4db2bbdd5ca766278f95fc039469031155d5fd535049444559",
+    "token_policy": "ab5a47a5e65559a94d4db2bbdd5ca766278f95fc039469031155d5fd",
+    "token_ascii": "SPIDEY",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "SPIDEY"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmYec86D2wWDW8h7NyWYqwcLAapTj8UoCVdwrVUQX12c6b, SnekX payment: 2ac06cf31040cf6a18d7524b4957318f8fc005eda6445511344a05945bdee880 