### PR TITLE
Register SnekX token - chama

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "920576d097b8fa33580d581838671ac55e498dbfb119dbea6ae82bc76368616d61": {
+    "token_id": "920576d097b8fa33580d581838671ac55e498dbfb119dbea6ae82bc76368616d61",
+    "token_policy": "920576d097b8fa33580d581838671ac55e498dbfb119dbea6ae82bc7",
+    "token_ascii": "chama",
+    "is_verified": true,
+    "decimals": "5",
+    "ticker": "chama"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: Qmbb2fv7STiunJomksMWD8tE4FF4XuJg7Ho6XYHyCzDji3, SnekX payment: ef5904445678eab1ac2aedcffa7591d42bb703a44831e86615170a7d70866fdf 