### PR TITLE
Register SnekX token - SHAR PEI

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "109dafcc56a014902d730d0db246ae9a8752b1b64df16e039c6fae6653484152504549": {
+    "token_id": "109dafcc56a014902d730d0db246ae9a8752b1b64df16e039c6fae6653484152504549",
+    "token_policy": "109dafcc56a014902d730d0db246ae9a8752b1b64df16e039c6fae66",
+    "token_ascii": "SHAR PEI",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "SHARPEI"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmXch6NEgCYEJ6VsMuxo9ZWghcaig4XpAktmu5qTfjSpAS, SnekX payment: 742e40ac08e654eb03aca6a3ed7b86e9fde99d6bc45ecd3350f2431a992c03fc 