### PR TITLE
Register SnekX token - BLOODYEAR

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "0b926d7819293309790dc246bcaae6c8b874d797f8a91a985e499672424c4f4f4459454152": {
+    "token_id": "0b926d7819293309790dc246bcaae6c8b874d797f8a91a985e499672424c4f4f4459454152",
+    "token_policy": "0b926d7819293309790dc246bcaae6c8b874d797f8a91a985e499672",
+    "token_ascii": "BLOODYEAR",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "BLOODYEAR"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmfNNZRYUQSkTn1N33KfxCLoPTaYEZKPJsntrYq4pg4bVH, SnekX payment: 28df26f7ae713caf008d103afaaf5c5ed6b084963a424d53e9f7a676b0c16bed 