### PR TITLE
Register SnekX token - CNN JOKE

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "59492752ddfa1c77284f48a02f017ce221fdb9aca7cc6519266b1955434e4e4a4f4b45": {
+    "token_id": "59492752ddfa1c77284f48a02f017ce221fdb9aca7cc6519266b1955434e4e4a4f4b45",
+    "token_policy": "59492752ddfa1c77284f48a02f017ce221fdb9aca7cc6519266b1955",
+    "token_ascii": "CNN JOKE",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "CNN"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmNuzouhuxa6Hhv29ed9hAKhfKsdymWWcpyai4eReHSRuY, SnekX payment: eb3bed5944799c44d82826b36343e8bb30bc4f84cc1ffc583f842f33acd5a07d 