### PR TITLE
Register SnekX token - ADADOG

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "4d492330967cbd3d75abc0ac4fd36537079da237f09d6222ce122a60414441444f47": {
+    "token_id": "4d492330967cbd3d75abc0ac4fd36537079da237f09d6222ce122a60414441444f47",
+    "token_policy": "4d492330967cbd3d75abc0ac4fd36537079da237f09d6222ce122a60",
+    "token_ascii": "ADADOG",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "ADADOG"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmZUodmDpkfEramb6bsqyQPBY7zwBGiLBHVckvSy7icy2W, SnekX payment: d5fc097643483d8339b1776e454304fdf017cebd219495ab5ca8df226c73b56e 