### PR TITLE
Register SnekX token - NikeAIR

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "268ba53159da8961e79072f2d0831d5b61209ee7bf03d58d79181dfd4e696b65414952": {
+    "token_id": "268ba53159da8961e79072f2d0831d5b61209ee7bf03d58d79181dfd4e696b65414952",
+    "token_policy": "268ba53159da8961e79072f2d0831d5b61209ee7bf03d58d79181dfd",
+    "token_ascii": "NikeAIR",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "AIR"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: Qma54SFNhTyDyUun5q2okpu6Vj56avMv4TZKhHLqz4QwMF, SnekX payment: 769bccfb4b4f66eaf8a56c72d6db710fb58801ea8012eef4c8d467ea7f6e44bf 