### PR TITLE
Register SnekX token - datcoin

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "09de0282493bc2b62a231e434eaa624e856cce6938f947689258ac14646174636f696e": {
+    "token_id": "09de0282493bc2b62a231e434eaa624e856cce6938f947689258ac14646174636f696e",
+    "token_policy": "09de0282493bc2b62a231e434eaa624e856cce6938f947689258ac14",
+    "token_ascii": "datcoin",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "DAT"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmfXo5AWhQRvRngz4txkun4tngdsuzQ5tT45q5mb7AURQr, SnekX payment: a44f3742285822a4486f8ac9f654aaada685245f16a4f1df2aa56f968ac3ba82 