### PR TITLE
Register SnekX token - Turd Coin

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "84624ec9771a92e5d4f41b794c98eefd15ab28e6310c28063c6949b754757264436f696e": {
+    "token_id": "84624ec9771a92e5d4f41b794c98eefd15ab28e6310c28063c6949b754757264436f696e",
+    "token_policy": "84624ec9771a92e5d4f41b794c98eefd15ab28e6310c28063c6949b7",
+    "token_ascii": "Turd Coin",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Turd"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmdxggYRNhxhv1riwsKgo3MQGNdSHXpBe2zwLvSr2Wi6qP, SnekX payment: 98c6acdc143758b1ade5aeab786750f47cef49db5dcd858364ac668a727cbc23 