### PR TITLE
Register SnekX token - OutsideIn 

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "0e80e091ff5bb8b69ccf5daf6b77ca794856aea33cc6a36ea7276c6d4f757473696465496e": {
+    "token_id": "0e80e091ff5bb8b69ccf5daf6b77ca794856aea33cc6a36ea7276c6d4f757473696465496e",
+    "token_policy": "0e80e091ff5bb8b69ccf5daf6b77ca794856aea33cc6a36ea7276c6d",
+    "token_ascii": "OutsideIn ",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "OutsideIn"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmTkKn1ZZQC3EWm7J53jDd2pzsZz6e68J6qJazGvQk9sUc, SnekX payment: 27dcae7a3bb0d2ee93a48c902134a3bd75b711e3a4e25ec2de2f6455bc002219 