### PR TITLE
Register SnekX token - Wally 

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "a382b4e5105e4959014fa837dbd40c316d1e08753cff00af1182220d57616c6c79": {
+    "token_id": "a382b4e5105e4959014fa837dbd40c316d1e08753cff00af1182220d57616c6c79",
+    "token_policy": "a382b4e5105e4959014fa837dbd40c316d1e08753cff00af1182220d",
+    "token_ascii": "Wally ",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Wally"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmeQCX9tFpkwJVFRhWzvL2nWCfcsqr5sCEdYyU47nVBcaX, SnekX payment: 6a368b855d8165b7c178c4d62158ecbde8aebc4ffef896bc8ab36ae05a8c89bb 