### PR TITLE
Register SnekX token - Rizz Coin

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "c0c3dded0805ceec22e212a8ba4cf785807bb6707b63c3c3eb59851652697a7a436f696e": {
+    "token_id": "c0c3dded0805ceec22e212a8ba4cf785807bb6707b63c3c3eb59851652697a7a436f696e",
+    "token_policy": "c0c3dded0805ceec22e212a8ba4cf785807bb6707b63c3c3eb598516",
+    "token_ascii": "Rizz Coin",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Rizz"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmRFoMAWSY9RFKo1atuJ6UfqxQEd3fJnUJc2TmyixW2SJK, SnekX payment: 6d70588ebe9ee7818094fdbb2905b9e5fa8c024ee7f88b392d5d8816339f8d61 