### PR TITLE
Register SnekX token - analos

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "2105b465225eeecc9561764fdd94311a4872e7299952b86004e6dc25616e616c6f73": {
+    "token_id": "2105b465225eeecc9561764fdd94311a4872e7299952b86004e6dc25616e616c6f73",
+    "token_policy": "2105b465225eeecc9561764fdd94311a4872e7299952b86004e6dc25",
+    "token_ascii": "analos",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "analos"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmaXbWssfKx5bVCnnTM92hHQfzY5vq3GcrdE5AhiykLH7v, SnekX payment: 149b37b5b53c717dda21fde8ea3a03890abc67d3132e8c423feea5aa2b8d19fe 