### PR TITLE
Register SnekX token - NEIRO

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "74a6ad72586a57c5b67e6061357d6b791417de926aad2a1f45b7e88c4e4549524f": {
+    "token_id": "74a6ad72586a57c5b67e6061357d6b791417de926aad2a1f45b7e88c4e4549524f",
+    "token_policy": "74a6ad72586a57c5b67e6061357d6b791417de926aad2a1f45b7e88c",
+    "token_ascii": "NEIRO",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "NEIRO"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmUG2QFfNpBstD7D4EE35p3sXjM2ddK3LjjE5uTBsvmnr8, SnekX payment: 714d3021526443e1d38865e4d9c7e174b33c8b530a38a3a15f24c204fd2a9cb8 