### PR TITLE
Register SnekX token - DOGEGG

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "f2537538f2df6b4f75d99a99599f9affc609c50c58545fd53e3ae332444f47454747": {
+    "token_id": "f2537538f2df6b4f75d99a99599f9affc609c50c58545fd53e3ae332444f47454747",
+    "token_policy": "f2537538f2df6b4f75d99a99599f9affc609c50c58545fd53e3ae332",
+    "token_ascii": "DOGEGG",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "DOGEGG"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmejDittbWnjnieNRkWCrHK8QnjJ4eJ1mRMnc93bq75JfU, SnekX payment: 2a60509c30846215e3427be548fe8ba4de70f8bd9c08a5dbb7d05d574779371c 