### PR TITLE
Register SnekX token - Frenbobs

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3648,5 +3648,13 @@
     "is_verified": true,
     "decimals": "3",
     "ticker": "BULL"
+  },
+  "028bf3b39ec4df8467983d9fd92cbfcac372d1e97cb70c6de7582f1c4672656e626f6273": {
+    "token_id": "028bf3b39ec4df8467983d9fd92cbfcac372d1e97cb70c6de7582f1c4672656e626f6273",
+    "token_policy": "028bf3b39ec4df8467983d9fd92cbfcac372d1e97cb70c6de7582f1c",
+    "token_ascii": "Frenbobs",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Frenbobs"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmReXpXSWy5F3FdPXu8VYEU6knCodqVHrPQy3oBnNRabWe, SnekX payment: 745e801b838c08acccbf008b22684ce809c1ea62624a3568268bd0d5d0edd7ec 