### PR TITLE
Register SnekX token - Kanan Token 

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "b25987179397c3aff776625d72c6fee30cbb6988d1f1d5790941f73d4b616e616e546f6b656e": {
+    "token_id": "b25987179397c3aff776625d72c6fee30cbb6988d1f1d5790941f73d4b616e616e546f6b656e",
+    "token_policy": "b25987179397c3aff776625d72c6fee30cbb6988d1f1d5790941f73d",
+    "token_ascii": "Kanan Token ",
+    "is_verified": true,
+    "decimals": "6",
+    "ticker": "KNT"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmYZQiwi1PNWhupWSomft5BVJ86q4CBEugiFtLQCPbHctg, SnekX payment: 728ed1f02dda9aa42170dac8c99dc3db0f919d4089f33204c7448d6e3440adfc 