### PR TITLE
Register SnekX token - Trenchy

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "76f69df3bcd3b9ce34df2aefd8028f251ede4ced13138eb80b4322085472656e636879": {
+    "token_id": "76f69df3bcd3b9ce34df2aefd8028f251ede4ced13138eb80b4322085472656e636879",
+    "token_policy": "76f69df3bcd3b9ce34df2aefd8028f251ede4ced13138eb80b432208",
+    "token_ascii": "Trenchy",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Trenchy"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmUqZoiBPAmDkRmXHVDmfRsWPTZFC2ZYyX1UPRjqtCTTug, SnekX payment: b99ff019c8cca970b68e0bc136a3a6023a834b116ba1b06245d4720183d623da 