### PR TITLE
Register SnekX token - LIDO

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "4e98b9e8d5ec47ddeebc9334cc62814d12b5dc19788e169672de58114c49444f": {
+    "token_id": "4e98b9e8d5ec47ddeebc9334cc62814d12b5dc19788e169672de58114c49444f",
+    "token_policy": "4e98b9e8d5ec47ddeebc9334cc62814d12b5dc19788e169672de5811",
+    "token_ascii": "LIDO",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "LIDO"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmPi7vk16rgai9nuxeL2uwcomfyzTyatbmRPDPkyNwoRzY, SnekX payment: 7f49b83503c5ee953512e0427495f61f8b30a7b257d3cb1e0ac4b51ce00c335c 