### PR TITLE
Register SnekX token - Skelly Doods Cabal

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "a6daaffe5fe9efd4783c2f767b8c812e8037c80d9234a7a2c4559f8e536b656c6c79446f6f6473436162616c": {
+    "token_id": "a6daaffe5fe9efd4783c2f767b8c812e8037c80d9234a7a2c4559f8e536b656c6c79446f6f6473436162616c",
+    "token_policy": "a6daaffe5fe9efd4783c2f767b8c812e8037c80d9234a7a2c4559f8e",
+    "token_ascii": "Skelly Doods Cabal",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "Cabal"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmU5NZbR6JC2MfEW4dsJE88t8Rfr5tkwSYC95WtS1ngVwo, SnekX payment: 56be20dcdec3109a9af3bee157fa6ed50025979d2a168cc8c1997add976fc98e 