### PR TITLE
Register SnekX token - Crypto Sockz

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "e13f55c16b8718edac43614146c00cadc45991af3a5355d0386a9f0343727970746f536f636b7a": {
+    "token_id": "e13f55c16b8718edac43614146c00cadc45991af3a5355d0386a9f0343727970746f536f636b7a",
+    "token_policy": "e13f55c16b8718edac43614146c00cadc45991af3a5355d0386a9f03",
+    "token_ascii": "Crypto Sockz",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "SOCKZ"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmcSJZWbpueNeejdUsWRmT9MeJZX8d9AQhSm4AvNjzX6qa, SnekX payment: 5550a67bb318f2a33435d587f591cddd26f211d7bcaabf16b93fb5690f238cd9 