### PR TITLE
Register SnekX token - FUDCOIN

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "e15cfc7376a4d6709c4fd241bb97ad6691a4130dfd65b254c77b4962465544434f494e": {
+    "token_id": "e15cfc7376a4d6709c4fd241bb97ad6691a4130dfd65b254c77b4962465544434f494e",
+    "token_policy": "e15cfc7376a4d6709c4fd241bb97ad6691a4130dfd65b254c77b4962",
+    "token_ascii": "FUDCOIN",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "FUD"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmPuRFJVd6BrYiXRy4TgS9mbGrXhHjF818CZb1WCYWAD1U, SnekX payment: d609d6b16eafc783faf41691ec255d4968406203332dce91ea3d0f6bc5cca03b 