### PR TITLE
Register SnekX token - muzon

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -3656,5 +3656,13 @@
     "is_verified": true,
     "decimals": "0",
     "ticker": "FIGHT"
+  },
+  "505dacc55ec1693ba86d2424c9f8372c485d04c124869347c1e744a26d757a6f6e": {
+    "token_id": "505dacc55ec1693ba86d2424c9f8372c485d04c124869347c1e744a26d757a6f6e",
+    "token_policy": "505dacc55ec1693ba86d2424c9f8372c485d04c124869347c1e744a2",
+    "token_ascii": "muzon",
+    "is_verified": true,
+    "decimals": "0",
+    "ticker": "mzn"
   }
 }


### PR DESCRIPTION
SnekX token approval. Token Image hash: QmbHGPm1zVeiX6QvRqDaApTo8tyMQiBfsaDSgPD9sF7qBe, SnekX payment: 1ec3b3523a33d31b8ad4da9bce973f897bdcef3dd75aa27c6b920dd7faeb6fc2 